### PR TITLE
[OT196-113] Test /users endpoints 

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -1,29 +1,36 @@
 require("dotenv").config();
+const env = process.env.NODE_ENV;
 
-module.exports = {
-  development: {
-    username: process.env.DB_USER,
-    password: process.env.DB_PASSWORD,
-    database: process.env.DB_NAME,
-    host: process.env.DB_HOST,
-    port: process.env.DB_PORT,
-    secretToken: process.env.DB_TOKEN,
-    dialect: "mysql",
-  },
-  test: {
-    username: process.env.DB_USER,
-    password: process.env.DB_PASSWORD,
-    database: process.env.DB_NAME_TEST,
-    host: process.env.DB_HOST,
-    secretToken: process.env.DB_TOKEN,
-    dialect: "mysql",
-  },
-  production: {
-    username: process.env.DB_USER,
-    password: process.env.DB_PASSWORD,
-    database: process.env.DB_NAME,
-    host: process.env.DB_HOST,
-    secretToken: process.env.DB_TOKEN,
-    dialect: "mysql",
-  },
+const development = {
+  username: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
+  host: process.env.DB_HOST,
+  port: process.env.DB_PORT,
+  secretToken: process.env.DB_TOKEN,
+  dialect: "mysql",
 };
+const test = {
+  username: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME_TEST,
+  host: process.env.DB_HOST,
+  secretToken: process.env.DB_TOKEN,
+  dialect: "mysql",
+};
+const production = {
+  username: process.env.DB_USER,
+  password: process.env.DB_PASSWORD,
+  database: process.env.DB_NAME,
+  host: process.env.DB_HOST,
+  secretToken: process.env.DB_TOKEN,
+  dialect: "mysql",
+};
+
+const config = {
+  development,
+  test,
+  production,
+};
+
+module.exports = config[env];

--- a/config/config.js
+++ b/config/config.js
@@ -1,29 +1,29 @@
-require('dotenv').config()
+require("dotenv").config();
 
 module.exports = {
-    "development": {
-        "username": process.env.DB_USER,
-        "password": process.env.DB_PASSWORD,
-        "database":  process.env.DB_NAME,
-        "host": process.env.DB_HOST,
-        "port": process.env.DB_PORT,
-        "secretToken": process.env.DB_TOKEN,
-        "dialect": "mysql"
-    },
-    "test": {
-        "username": process.env.DB_USER,
-        "password": process.env.DB_PASSWORD,
-        "database": process.env.DB_NAME,
-        "host": process.env.DB_HOST,
-        "secretToken": process.env.DB_TOKEN,
-        "dialect": "mysql"
-    },
-    "production": {
-        "username": process.env.DB_USER,
-        "password": process.env.DB_PASSWORD,
-        "database": process.env.DB_NAME,
-        "host": process.env.DB_HOST,
-        "secretToken": process.env.DB_TOKEN,
-        "dialect": "mysql"
-    }
-}
+  development: {
+    username: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME,
+    host: process.env.DB_HOST,
+    port: process.env.DB_PORT,
+    secretToken: process.env.DB_TOKEN,
+    dialect: "mysql",
+  },
+  test: {
+    username: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME_TEST,
+    host: process.env.DB_HOST,
+    secretToken: process.env.DB_TOKEN,
+    dialect: "mysql",
+  },
+  production: {
+    username: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME,
+    host: process.env.DB_HOST,
+    secretToken: process.env.DB_TOKEN,
+    dialect: "mysql",
+  },
+};

--- a/controllers/userValidator.js
+++ b/controllers/userValidator.js
@@ -1,30 +1,32 @@
-const { check, validationResult } = require('express-validator');
+const { check, validationResult } = require("express-validator");
 
 const validateCreate = [
-    check('firstName')
-      .exists()
-      .not()
-      .isEmpty(),
-    check('lastName')
-      .exists()
-      .not()
-      .isEmpty(),
-    check('email')
-      .exists()
-      .isEmail(),
-    check('password')
-      .exists()
-      .not()
-      .isEmpty(),
-    (req, res, next) => {
-        try {
-            validationResult(req).throw()
-            return next()
-        } catch (err) {
-            res.status(403)
-            res.send({ errors: err.array() })
-        }
+  check("firstName").exists().not().isEmpty(),
+  check("lastName").exists().not().isEmpty(),
+  check("email").exists().isEmail(),
+  check("password").exists().not().isEmpty(),
+  (req, res, next) => {
+    try {
+      validationResult(req).throw();
+      return next();
+    } catch (err) {
+      res.status(403);
+      res.send({ errors: err.array() });
     }
-]
+  },
+];
 
-module.exports = validateCreate;
+const validateId = [
+  check("id").exists().not().isEmpty().isInt(),
+  (req, res, next) => {
+    try {
+      validationResult(req).throw();
+      return next();
+    } catch (err) {
+      res.status(403);
+      res.send({ errors: err.array() });
+    }
+  },
+];
+
+module.exports = { validateCreate, validateId };

--- a/controllers/userValidator.js
+++ b/controllers/userValidator.js
@@ -1,3 +1,4 @@
+const e = require("express");
 const { check, validationResult } = require("express-validator");
 
 const validateCreate = [
@@ -5,6 +6,19 @@ const validateCreate = [
   check("lastName").exists().not().isEmpty(),
   check("email").exists().isEmail(),
   check("password").exists().not().isEmpty(),
+  (req, res, next) => {
+    try {
+      validationResult(req).throw();
+      return next();
+    } catch (err) {
+      res.status(403);
+      res.send({ errors: err.array() });
+    }
+  },
+];
+
+const validateEmail = [
+  check("email").exists().bail().isEmail(),
   (req, res, next) => {
     try {
       validationResult(req).throw();
@@ -29,4 +43,4 @@ const validateId = [
   },
 ];
 
-module.exports = { validateCreate, validateId };
+module.exports = { validateCreate, validateId, validateEmail };

--- a/controllers/usersController.js
+++ b/controllers/usersController.js
@@ -26,7 +26,7 @@ exports.registerUser = async (req, res) => {
     roleId: 2,
     image:
       "https://www.business2community.com/wp-content/uploads/2017/08/blank-profile-picture-973460_640.png",
-  }).then((user) => res.json(user));
+  }).then((user) => res.status(200).json(user));
 };
 
 exports.deleteUser = async (req, res) => {
@@ -35,9 +35,15 @@ exports.deleteUser = async (req, res) => {
     await User.destroy({
       where: { id },
     });
-    res.send("The user has been deleted correctly");
+    res.status(200).send({
+      success: true,
+      message: "The user has been deleted correctly",
+    });
   } catch (error) {
-    console.log(error);
+    return res.status(500).send({
+      success: false,
+      message: e.message,
+    });
   }
 };
 

--- a/controllers/usersController.js
+++ b/controllers/usersController.js
@@ -20,14 +20,12 @@ exports.getAllUsers = async (req, res, next) => {
 exports.registerUser = async (req, res) => {
   const userExist = await User.findOne({ where: { email: req.body.email } });
   if (userExist)
-    return res
-      .status(500)
-      .json({
-        success: false,
-        message: "Ya hay una cuenta registrada con ese correo.",
-      });
+    return res.status(500).json({
+      success: false,
+      message: "Ya hay una cuenta registrada con ese correo.",
+    });
   let passwordHash = await bcrypt.hash(req.body.password, 10);
-  User.create({
+  const user = await User.create({
     firstName: req.body.firstName,
     lastName: req.body.lastName,
     email: req.body.email,
@@ -35,10 +33,13 @@ exports.registerUser = async (req, res) => {
     roleId: 2,
     image:
       "https://www.business2community.com/wp-content/uploads/2017/08/blank-profile-picture-973460_640.png",
-  }).then((user) => {
-    sendEmail({ name: req.body.firstName, email: req.body.email }, "register");
-    res.status(200).json(user);
   });
+
+  await sendEmail(
+    { name: req.body.firstName, email: req.body.email },
+    "register"
+  );
+  res.status(200).json(user);
 };
 
 exports.deleteUser = async (req, res) => {

--- a/migrations/20220609145138-Update-activity.js
+++ b/migrations/20220609145138-Update-activity.js
@@ -1,11 +1,15 @@
-'use strict';
+"use strict";
 
 module.exports = {
-  async up (queryInterface, Sequelize) {
-    await queryInterface.changeColumn('Activities', 'content', {type: Sequelize.STRING(2500)})
+  async up(queryInterface, Sequelize) {
+    await queryInterface.changeColumn("Activities", "content", {
+      type: Sequelize.STRING(2500),
+    });
   },
 
-  async down (queryInterface, Sequelize) {
-    await queryInterface.changeColumn('Activities', 'content', {type: Sequelize.STRING})
-  }
+  async down(queryInterface, Sequelize) {
+    await queryInterface.changeColumn("Activities", "content", {
+      type: Sequelize.STRING(2500),
+    });
+  },
 };

--- a/models/index.js
+++ b/models/index.js
@@ -1,27 +1,36 @@
-'use strict';
+"use strict";
 
-const fs = require('fs');
-const path = require('path');
-const Sequelize = require('sequelize');
+const fs = require("fs");
+const path = require("path");
+const Sequelize = require("sequelize");
 const basename = path.basename(__filename);
-const config = require(__dirname + '/../config/config').development;
+const config = require(__dirname + "/../config/config");
 const db = {};
 
-const sequelize = new Sequelize(config.database, config.username, config.password, config);
+const sequelize = new Sequelize(
+  config.database,
+  config.username,
+  config.password,
+  config
+);
 
-fs
-  .readdirSync(__dirname)
-  .filter(file => {
-    return (file.indexOf('.') !== 0) && (file !== basename) && (file.slice(-3) === '.js');
+fs.readdirSync(__dirname)
+  .filter((file) => {
+    return (
+      file.indexOf(".") !== 0 && file !== basename && file.slice(-3) === ".js"
+    );
   })
-  .forEach(file => {
-    const model = require(path.join(__dirname, file))(sequelize, Sequelize.DataTypes);
+  .forEach((file) => {
+    const model = require(path.join(__dirname, file))(
+      sequelize,
+      Sequelize.DataTypes
+    );
     db[model.name] = model;
   });
 
-Object.keys(db).forEach(modelName => {
+Object.keys(db).forEach((modelName) => {
   if (db[modelName].associate) {
-    db[modelName].associate(db); 
+    db[modelName].associate(db);
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,8 @@
     "sequelize": "^6.3.5"
   },
   "devDependencies": {
-    "sequelize-cli": "^6.2.0"
+    "jest": "^28.1.2",
+    "sequelize-cli": "^6.2.0",
+    "supertest": "^6.2.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,11 @@
   "private": true,
   "scripts": {
     "start": "node ./bin/www",
-    "inspect": "nodemon --inspect ./bin/www"
+    "inspect": "nodemon --inspect ./bin/www",
+    "migrate": "npx sequelize-cli db:migrate",
+    "migrate:reset": "npx sequelize-cli db:migrate:undo:all && npm run migrate",
+    "test": "cross-env NODE_ENV=test jest --testTimeout=10000",
+    "pretest": "cross-env NODE_ENV=test npm run migrate:reset"
   },
   "dependencies": {
     "@sendgrid/mail": "^7.7.0",
@@ -26,8 +30,15 @@
     "sequelize": "^6.3.5"
   },
   "devDependencies": {
+    "cross-env": "^7.0.3",
     "jest": "^28.1.2",
     "sequelize-cli": "^6.2.0",
     "supertest": "^6.2.3"
+  },
+  "jest": {
+    "testEnvironment": "node",
+    "coveragePathIgnorePatterns": [
+      "/node_modules/"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,9 +5,10 @@
   "scripts": {
     "start": "node ./bin/www",
     "inspect": "nodemon --inspect ./bin/www",
-    "migrate": "npx sequelize-cli db:migrate",
+    "seeder": " npx sequelize-cli db:seed:all",
+    "migrate": "npx sequelize-cli db:migrate && npm run seeder",
     "migrate:reset": "npx sequelize-cli db:migrate:undo:all && npm run migrate",
-    "test": "cross-env NODE_ENV=test jest --testTimeout=10000",
+    "test": "cross-env NODE_ENV=test jest --detectOpenHandles --testTimeout=10000",
     "pretest": "cross-env NODE_ENV=test npm run migrate:reset"
   },
   "dependencies": {

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,10 +1,9 @@
 var express = require("express");
 var router = express.Router();
-const validateCreate = require("../controllers/userValidator");
+const { validateCreate, validateId } = require("../controllers/userValidator");
 const { adminValidation } = require("../middlewares/validators/userValidators");
 const {
   getAllUsers,
-  getLoggedUser,
   registerUser,
   deleteUser,
   updateUser,
@@ -17,9 +16,9 @@ router.get("/", adminValidation, getAllUsers);
 router.post("/auth/register", validateCreate, registerUser);
 
 // Delete user
-router.delete("/:id", deleteUser);
+router.delete("/:id", adminValidation, validateId, deleteUser);
 
 // Update user
-router.put("/:id", adminValidation, updateUser);
+router.put("/:id", adminValidation, validateId, updateUser);
 
 module.exports = router;

--- a/routes/users.js
+++ b/routes/users.js
@@ -1,6 +1,10 @@
 var express = require("express");
 var router = express.Router();
-const { validateCreate, validateId } = require("../controllers/userValidator");
+const {
+  validateCreate,
+  validateId,
+  validateEmail,
+} = require("../controllers/userValidator");
 const { adminValidation } = require("../middlewares/validators/userValidators");
 const {
   getAllUsers,
@@ -19,6 +23,6 @@ router.post("/auth/register", validateCreate, registerUser);
 router.delete("/:id", adminValidation, validateId, deleteUser);
 
 // Update user
-router.put("/:id", adminValidation, validateId, updateUser);
+router.put("/:id", adminValidation, validateId, validateEmail, updateUser);
 
 module.exports = router;

--- a/tests/users.test.js
+++ b/tests/users.test.js
@@ -1,5 +1,6 @@
 const request = require("supertest");
 const app = require("../app");
+const { User } = require("../models/index");
 
 const testUser = {
   email: "usuarionormal@mail.com",
@@ -7,8 +8,8 @@ const testUser = {
 };
 
 const testAdmin = {
-  email: "usuarioadmin@mail.com",
-  password: "admin",
+  email: "ezequielalmada@mail.com",
+  password: "almada",
 };
 
 describe("GET /users", () => {
@@ -49,5 +50,84 @@ describe("GET /users", () => {
         .expect(200)
         .expect("Content-Type", /application\/json/);
     }, 100000);
+  });
+});
+
+describe("DELETE /users/:id", () => {
+  test("Fails: user is not logged in", async () => {
+    await request(app).delete("/users/1").expect(401);
+  }, 100000);
+
+  describe("If user is logged in", () => {
+    test("Fails: user is not an admin", async () => {
+      const loggedUser = await request(app)
+        .post("/auth/login")
+        .send({
+          email: testUser.email,
+          password: testUser.password,
+        })
+        .expect(200)
+        .expect("Content-Type", /application\/json/);
+
+      await request(app)
+        .delete(`/users/1`)
+        .set("Authorization", `Bearer ${loggedUser.body.user.token}`)
+        .expect(403);
+    }, 100000);
+
+    describe("If user is admin", () => {
+      test("Fails: id is not valid", async () => {
+        const invalidId = "12jhhj31231";
+
+        const loggedUser = await request(app)
+          .post("/auth/login")
+          .send({
+            email: testAdmin.email,
+            password: testAdmin.password,
+          })
+          .expect(200)
+          .expect("Content-Type", /application\/json/);
+
+        await request(app)
+          .delete(`/users/${invalidId}`)
+          .set("Authorization", `Bearer ${loggedUser.body.user.token}`)
+          .expect(403);
+      }, 100000);
+
+      test("Success: id is valid", async () => {
+        const testNewUser = {
+          firstName: "Will Be",
+          lastName: "Deleted",
+          email: "willbedeleted@mail.com",
+          password: "deleted",
+          roleId: 2,
+        };
+
+        await request(app)
+          .post("/users/auth/register")
+          .send(testNewUser)
+          .expect(200)
+          .expect("Content-Type", /application\/json/);
+
+        const loggedUser = await request(app)
+          .post("/auth/login")
+          .send({
+            email: testAdmin.email,
+            password: testAdmin.password,
+          })
+          .expect(200)
+          .expect("Content-Type", /application\/json/);
+
+        const userToDelete = await User.findOne({
+          where: { email: testNewUser.email },
+        });
+
+        await request(app)
+          .delete(`/users/${userToDelete.id}`)
+          .set("Authorization", `Bearer ${loggedUser.body.user.token}`)
+          .expect(200)
+          .expect("Content-Type", /application\/json/);
+      }, 100000);
+    });
   });
 });

--- a/tests/users.test.js
+++ b/tests/users.test.js
@@ -131,3 +131,90 @@ describe("DELETE /users/:id", () => {
     });
   });
 });
+
+describe("PUT /users/:id", () => {
+  test("Fails: user is not logged in", async () => {
+    await request(app).put("/users/1").expect(401);
+  }, 100000);
+
+  describe("If user is logged in", () => {
+    test("Fails: user is not an admin", async () => {
+      const loggedUser = await request(app)
+        .post("/auth/login")
+        .send({
+          email: testUser.email,
+          password: testUser.password,
+        })
+        .expect(200)
+        .expect("Content-Type", /application\/json/);
+
+      await request(app)
+        .delete(`/users/1`)
+        .set("Authorization", `Bearer ${loggedUser.body.user.token}`)
+        .expect(403);
+    }, 100000);
+
+    describe("If user is admin", () => {
+      test("Fails: id is not valid", async () => {
+        const invalidId = "12jhhj31231";
+
+        const loggedUser = await request(app)
+          .post("/auth/login")
+          .send({
+            email: testAdmin.email,
+            password: testAdmin.password,
+          })
+          .expect(200)
+          .expect("Content-Type", /application\/json/);
+
+        await request(app)
+          .delete(`/users/${invalidId}`)
+          .set("Authorization", `Bearer ${loggedUser.body.user.token}`)
+          .expect(403);
+      }, 100000);
+
+      test("Success: id is valid", async () => {
+        const testNewUser = {
+          firstName: "Will Be",
+          lastName: "Updated",
+          email: "willbeupdated@mail.com",
+          password: "willbeupdated",
+          roleId: 2,
+        };
+
+        const updates = {
+          firstName: "Updated",
+          lastName: "User",
+          email: "updated@mail.com",
+          password: "updated",
+        };
+
+        await request(app)
+          .post("/users/auth/register")
+          .send(testNewUser)
+          .expect(200)
+          .expect("Content-Type", /application\/json/);
+
+        const loggedUser = await request(app)
+          .post("/auth/login")
+          .send({
+            email: testAdmin.email,
+            password: testAdmin.password,
+          })
+          .expect(200)
+          .expect("Content-Type", /application\/json/);
+
+        const userToUpdate = await User.findOne({
+          where: { email: testNewUser.email },
+        });
+
+        await request(app)
+          .delete(`/users/${userToUpdate.id}`)
+          .set("Authorization", `Bearer ${loggedUser.body.user.token}`)
+          .send(updates)
+          .expect(200)
+          .expect("Content-Type", /application\/json/);
+      }, 100000);
+    });
+  });
+});

--- a/tests/users.test.js
+++ b/tests/users.test.js
@@ -12,6 +12,17 @@ const testAdmin = {
   password: "almada",
 };
 
+const logUser = async (user) => {
+  return await request(app)
+    .post("/auth/login")
+    .send({
+      email: user.email,
+      password: user.password,
+    })
+    .expect(200)
+    .expect("Content-Type", /application\/json/);
+};
+
 describe("GET /users", () => {
   test("Fails: user not logged in", async () => {
     await request(app).get("/users").expect(401);
@@ -19,14 +30,7 @@ describe("GET /users", () => {
 
   describe("If user is logged in", () => {
     test("Fails: user is not an admin", async () => {
-      const loggedUser = await request(app)
-        .post("/auth/login")
-        .send({
-          email: testUser.email,
-          password: testUser.password,
-        })
-        .expect(200)
-        .expect("Content-Type", /application\/json/);
+      const loggedUser = await logUser(testUser);
 
       await request(app)
         .get("/users")
@@ -35,14 +39,7 @@ describe("GET /users", () => {
     }, 100000);
 
     test("Succeeds: user is admin", async () => {
-      const loggedUser = await request(app)
-        .post("/auth/login")
-        .send({
-          email: testAdmin.email,
-          password: testAdmin.password,
-        })
-        .expect(200)
-        .expect("Content-Type", /application\/json/);
+      const loggedUser = await logUser(testAdmin);
 
       await request(app)
         .get("/users")
@@ -60,14 +57,7 @@ describe("DELETE /users/:id", () => {
 
   describe("If user is logged in", () => {
     test("Fails: user is not an admin", async () => {
-      const loggedUser = await request(app)
-        .post("/auth/login")
-        .send({
-          email: testUser.email,
-          password: testUser.password,
-        })
-        .expect(200)
-        .expect("Content-Type", /application\/json/);
+      const loggedUser = await logUser(testUser);
 
       await request(app)
         .delete(`/users/1`)
@@ -79,14 +69,7 @@ describe("DELETE /users/:id", () => {
       test("Fails: id is not valid", async () => {
         const invalidId = "12jhhj31231";
 
-        const loggedUser = await request(app)
-          .post("/auth/login")
-          .send({
-            email: testAdmin.email,
-            password: testAdmin.password,
-          })
-          .expect(200)
-          .expect("Content-Type", /application\/json/);
+        const loggedUser = await logUser(testAdmin);
 
         await request(app)
           .delete(`/users/${invalidId}`)
@@ -109,14 +92,7 @@ describe("DELETE /users/:id", () => {
           .expect(200)
           .expect("Content-Type", /application\/json/);
 
-        const loggedUser = await request(app)
-          .post("/auth/login")
-          .send({
-            email: testAdmin.email,
-            password: testAdmin.password,
-          })
-          .expect(200)
-          .expect("Content-Type", /application\/json/);
+        const loggedUser = await logUser(testAdmin);
 
         const userToDelete = await User.findOne({
           where: { email: testNewUser.email },
@@ -139,14 +115,7 @@ describe("PUT /users/:id", () => {
 
   describe("If user is logged in", () => {
     test("Fails: user is not an admin", async () => {
-      const loggedUser = await request(app)
-        .post("/auth/login")
-        .send({
-          email: testUser.email,
-          password: testUser.password,
-        })
-        .expect(200)
-        .expect("Content-Type", /application\/json/);
+      const loggedUser = await logUser(testUser);
 
       await request(app)
         .delete(`/users/1`)
@@ -158,14 +127,7 @@ describe("PUT /users/:id", () => {
       test("Fails: id is not valid", async () => {
         const invalidId = "12jhhj31231";
 
-        const loggedUser = await request(app)
-          .post("/auth/login")
-          .send({
-            email: testAdmin.email,
-            password: testAdmin.password,
-          })
-          .expect(200)
-          .expect("Content-Type", /application\/json/);
+        const loggedUser = await logUser(testAdmin);
 
         await request(app)
           .delete(`/users/${invalidId}`)
@@ -195,14 +157,7 @@ describe("PUT /users/:id", () => {
           .expect(200)
           .expect("Content-Type", /application\/json/);
 
-        const loggedUser = await request(app)
-          .post("/auth/login")
-          .send({
-            email: testAdmin.email,
-            password: testAdmin.password,
-          })
-          .expect(200)
-          .expect("Content-Type", /application\/json/);
+        const loggedUser = await logUser(testAdmin);
 
         const userToUpdate = await User.findOne({
           where: { email: testNewUser.email },

--- a/tests/users.test.js
+++ b/tests/users.test.js
@@ -196,8 +196,6 @@ describe("PUT /users/:id", () => {
             roleId: 2,
           };
 
-          await testRequest("post", "/users/auth/register", 200, testNewUser);
-
           const loggedUser = await logUser(testAdmin);
 
           const userToUpdate = await User.findOne({

--- a/tests/users.test.js
+++ b/tests/users.test.js
@@ -1,0 +1,53 @@
+const request = require("supertest");
+const app = require("../app");
+
+const testUser = {
+  email: "usuarionormal@mail.com",
+  password: "normal",
+};
+
+const testAdmin = {
+  email: "usuarioadmin@mail.com",
+  password: "admin",
+};
+
+describe("GET /users", () => {
+  test("Fails: user not logged in", async () => {
+    await request(app).get("/users").expect(401);
+  }, 100000);
+
+  describe("If user is logged in", () => {
+    test("Fails: user is not an admin", async () => {
+      const loggedUser = await request(app)
+        .post("/auth/login")
+        .send({
+          email: testUser.email,
+          password: testUser.password,
+        })
+        .expect(200)
+        .expect("Content-Type", /application\/json/);
+
+      await request(app)
+        .get("/users")
+        .set("Authorization", `Bearer ${loggedUser.body.user.token}`)
+        .expect(403);
+    }, 100000);
+
+    test("Succeeds: user is admin", async () => {
+      const loggedUser = await request(app)
+        .post("/auth/login")
+        .send({
+          email: testAdmin.email,
+          password: testAdmin.password,
+        })
+        .expect(200)
+        .expect("Content-Type", /application\/json/);
+
+      await request(app)
+        .get("/users")
+        .set("Authorization", `Bearer ${loggedUser.body.user.token}`)
+        .expect(200)
+        .expect("Content-Type", /application\/json/);
+    }, 100000);
+  });
+});

--- a/utils/emailSender.js
+++ b/utils/emailSender.js
@@ -6,7 +6,7 @@ formatMessage.setup({ missingTranslation: "ignore" });
 sgMail.setApiKey(process.env.SENDGRID_API_KEY);
 
 // Set EMAIL SENDER validated on SENDGRID
-const emailSender = "zeque-mati@hotmail.com";
+const emailSender = "";
 
 const emailTemplates = {
   ["default"]: {

--- a/utils/emailSender.js
+++ b/utils/emailSender.js
@@ -6,7 +6,7 @@ formatMessage.setup({ missingTranslation: "ignore" });
 sgMail.setApiKey(process.env.SENDGRID_API_KEY);
 
 // Set EMAIL SENDER validated on SENDGRID
-const emailSender = "";
+const emailSender = "zeque-mati@hotmail.com";
 
 const emailTemplates = {
   ["default"]: {
@@ -40,12 +40,10 @@ exports.sendEmail = async function (mailData, type) {
     subject: subject,
     html: html,
   };
-  sgMail
-    .send(msg)
-    .then(() => {
-      console.log(`Email sent to ${mailData.email} from ${emailSender}`);
-    })
-    .catch((e) => {
-      console.error(e);
-    });
+  try {
+    await sgMail.send(msg);
+    console.log(`Email sent to ${mailData.email} from ${emailSender}`);
+  } catch (error) {
+    console.error(e);
+  }
 };


### PR DESCRIPTION
https://alkemy-labs.atlassian.net/browse/OT196-113
The only endpoint I didn't test was users/auth/register because it has to me moved to /auth routes.

### Summary
- Modified **config.js**: Now it sets the variables depending on the .env.
- New **email and id validators** for /users
- **Modified** some **users controllers** to respond with a server status.
- Solved bug on the **activities** migrations: **now the migration can be undone**.
- Updated **index.js**: now it does not config on development by default.
- Added some **scripts** and **dependencies** on **package.json** for Testing.
- **Tests**: new feature to test the _/users_ endpoints. It tests:
    1. `GET /users`: Fails on user not logged in or not admin role. Success case if it does't fail on the previous conditions.
    2. `DELETE /users/:id`: user not logged in, not admin role or not valid id. Success case if it does't fail on the previous conditions.
    3. `PUT /users/:id`: user not logged in, not admin role, not valid id or not valid email.  Success case if it does't fail on the previous conditions.

### Evidence

Every test on /users
![image](https://user-images.githubusercontent.com/90068543/177212593-2bc319d0-798c-461c-be75-b5989a6799f9.png)
